### PR TITLE
Make license ID SPDX-conformant

### DIFF
--- a/maubot.yaml
+++ b/maubot.yaml
@@ -1,7 +1,7 @@
 maubot: 0.1.0
 id: com.elishaaz.maulocalstt
 version: 1.0.2
-license: GPLv3
+license: GPL-3.0-only
 modules:
   - maulocalstt
 main_class: MauLocalSTT


### PR DESCRIPTION
This field is supposed to be an SPDX license ID. "GPLv3" isn't a valid SPDX license ID.

See https://spdx.org/licenses/ for a full list of those licenses.